### PR TITLE
Fix(CI): Fix pycairo installation failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,11 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install system dependencies
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y libcairo2-dev pkg-config
+
       - name: Install Poetry
         run: pip install poetry==2.1.1
 


### PR DESCRIPTION
Adds a step to install `libcairo2-dev` in the CI workflow, resolving the `pycairo` compilation error.

Fixes #90 