### PR TITLE
Add allow-prereleases for pysatl-criterion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dacite = "==1.9.2"
 line_profiler = "5.0.2"
 pydantic = "^2.11.9"
 psycopg2 = "2.9.12"
-pysatl-criterion = { version = "*", source = "testpypi" }
+pysatl-criterion = { version = "*", source = "testpypi", allow-prereleases = true }
 psutil = "^7.1.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/pysatl_experiment/persistence/random_values_storage.py
+++ b/pysatl_experiment/persistence/random_values_storage.py
@@ -59,7 +59,7 @@ class AlchemyRandomValues(ModelBase):
     generator_parameters: Mapped[str] = mapped_column(String, nullable=False, index=True)  # type: ignore
     sample_size: Mapped[int] = mapped_column(Integer, nullable=False, index=True)  # type: ignore
     sample_num: Mapped[int] = mapped_column(Integer, nullable=False)  # type: ignore
-    data: Mapped[list[float]] = mapped_column(CompressedFloatArray(use_float32=True), nullable=False)  # type: ignore
+    data: Mapped[list[float]] = mapped_column(CompressedFloatArray(), nullable=False)  # type: ignore
 
     __table_args__ = (
         UniqueConstraint(


### PR DESCRIPTION
<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant?
-->
## Summary

<!-- Explain in one sentence the goal of this PR -->

Float 32 format is too small. Now float64 is used.

## Quick changelog

- Add allow-prereleases for pysatl-criterion
- Compress float with float64

## What's new?

Add allow-prereleases for pysatl-criterion. 
Compress float with float64.
